### PR TITLE
Swapped around max_hp and current_hp in check method display

### DIFF
--- a/ASCII GAME/Program.cs
+++ b/ASCII GAME/Program.cs
@@ -310,7 +310,7 @@ namespace ASCII_GAME
                     Required += 20;
                 }
                 Console.WriteLine("Player Stats:");
-                Console.WriteLine($"\tHP  : {max_HP}/{current_HP}");
+                Console.WriteLine($"\tHP  : {current_HP}/{max_HP}");
                 Console.WriteLine($"\tATT : {ATT}");
                 Console.WriteLine($"\tDEF : {DEF}");
                 Console.WriteLine($"\tSPD : {SPD}");


### PR DESCRIPTION
Fix #3 
In user display hp was displayed as  max_hp/current_hp, to fix this I have swapped them around, to make current_hp/max_hp